### PR TITLE
Add Windows build

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -36,12 +36,10 @@ jobs:
           git checkout ${{ matrix.duckdb_version }}
 
       - name: Build extension
-        # using debug for quick testing for now
         run: |
-          make debug
+          make release
 
       - name: Test Extension
         shell: bash
-        # using debug for quick testing for now
         run: |
-          build/debug/test/Debug/unittest.exe --test-dir . "[sql]"
+          build/release/test/Release/unittest.exe --test-dir . "[sql]"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -1,0 +1,47 @@
+name: Windows
+on: [push, pull_request,repository_dispatch]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  cancel-in-progress: true
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  windows:
+    name: Release
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        # Add commits/tags to build against other DuckDB versions
+        duckdb_version: [ '<submodule_version>' ]
+    env:
+      GEN: Ninja
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      - name: Checkout DuckDB to version
+        # Add commits/tags to build against other DuckDB versions
+        if: ${{ matrix.duckdb_version != '<submodule_version>'}}
+        run: |
+          cd duckdb
+          git checkout ${{ matrix.duckdb_version }}
+
+      - name: Build extension
+        # using debug for quick testing for now
+        run: |
+          make debug
+
+      - name: Test Extension
+        shell: bash
+        # using debug for quick testing for now
+        run: |
+          build/debug/test/Debug/unittest.exe --test-dir . "[sql]"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
-# IT BUILT!
 cmake_minimum_required(VERSION 2.8.12)
-
-message("MSG: WIN32 is ${WIN32}")
-message("MSG: OS_NAME is ${OS_NAME}")
 
 # Set extension name here
 set(TARGET_NAME arrow)
@@ -23,17 +19,6 @@ else()
     set(OSX_ARCH_FLAG "")
 endif()
 
-if(WIN32)
-    message("MSG: setting initial vars for WIN32")
-    # set(BYPRODUCT_LIB_FILE "arrow_static.lib")
-    # set(DUCKDB_EXTRA_LINK_FLAGS arrow)
-else()
-    message("MSG: setting initial vars for NOT windows")
-    set(BYPRODUCT_LIB_FILE "libarrow.a")
-endif()
-
-message("MSG: BYPRODUCT_LIB_FILE is: ${BYPRODUCT_LIB_FILE}")
-
 # Building Arrow
 include(ExternalProject)
 ExternalProject_Add(
@@ -42,7 +27,7 @@ ExternalProject_Add(
         GIT_TAG ea6875fd2a3ac66547a9a33c5506da94f3ff07f2
         PREFIX "${CMAKE_BINARY_DIR}/third_party/arrow"
         INSTALL_DIR "${CMAKE_BINARY_DIR}/third_party/arrow/install"
-        BUILD_BYPRODUCTS "<INSTALL_DIR>/lib/${BYPRODUCT_LIB_FILE}"
+        BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libarrow.a
         CONFIGURE_COMMAND
         ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${OSX_ARCH_FLAG}
         -DCMAKE_BUILD_TYPE=Release
@@ -68,27 +53,19 @@ ExternalProject_Add(
 
 ExternalProject_Get_Property(ARROW_EP install_dir)
 add_library(arrow STATIC IMPORTED GLOBAL)
-set_target_properties(arrow PROPERTIES IMPORTED_LOCATION "${install_dir}/lib/${BYPRODUCT_LIB_FILE}")
+set_target_properties(arrow PROPERTIES IMPORTED_LOCATION ${install_dir}/lib/libarrow.a)
 
 # create static library
 add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES})
 add_dependencies(${EXTENSION_NAME} ARROW_EP)
-if(WIN32)
-    message("MSG: Adding compile macro to EXTENSION_NAME")
-    # target_compile_definitions(${EXTENSION_NAME} PRIVATE ARROW_STATIC)
-endif()
 target_link_libraries(${EXTENSION_NAME} PUBLIC arrow)
 target_include_directories(${EXTENSION_NAME} PRIVATE ${install_dir}/include)
 
 # create loadable extension
 set(PARAMETERS "-warnings")
-# target_link_libraries(${TARGET_NAME}_loadable_extension PUBLIC arrow_static)
 build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES})
 add_dependencies(${TARGET_NAME}_loadable_extension ARROW_EP)
-if(WIN32)
-    message("MSG: Adding compile def to TARGET_NAME")
-    # target_compile_definitions(${TARGET_NAME}_loadable_extension PUBLIC ARROW_STATIC)
-endif()
+target_link_libraries(${TARGET_NAME}_loadable_extension arrow)
 target_include_directories(${TARGET_NAME}_loadable_extension PRIVATE ${install_dir}/include)
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ else()
     set(OSX_ARCH_FLAG "")
 endif()
 
+if(WIN32)
+    set(DUCKDB_EXTRA_LINK_FLAGS arrow)
+endif()
+
 # Building Arrow
 include(ExternalProject)
 ExternalProject_Add(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,11 @@ ExternalProject_Add(
 
 ExternalProject_Get_Property(ARROW_EP install_dir)
 add_library(arrow STATIC IMPORTED GLOBAL)
-set_target_properties(arrow PROPERTIES IMPORTED_LOCATION ${install_dir}/lib/libarrow.a)
+if(WIN32)
+    set_target_properties(arrow PROPERTIES IMPORTED_LOCATION ${install_dir}/lib/arrow_static.lib)
+else()
+    set_target_properties(arrow PROPERTIES IMPORTED_LOCATION ${install_dir}/lib/libarrow.a)
+endif()
 
 # create static library
 add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,9 @@ set(PARAMETERS "-warnings")
 build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES})
 add_dependencies(${TARGET_NAME}_loadable_extension ARROW_EP)
 target_link_libraries(${TARGET_NAME}_loadable_extension arrow)
+if(WIN32)
+    target_compile_definitions(${TARGET_NAME}_loadable_extension PUBLIC ARROW_STATIC)
+endif()
 target_include_directories(${TARGET_NAME}_loadable_extension PRIVATE ${install_dir}/include)
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,6 @@ else()
     set(OSX_ARCH_FLAG "")
 endif()
 
-if(WIN32)
-    set(DUCKDB_EXTRA_LINK_FLAGS arrow)
-endif()
-
 # Building Arrow
 include(ExternalProject)
 ExternalProject_Add(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
+# IT BUILT!
 cmake_minimum_required(VERSION 2.8.12)
+
+message("MSG: WIN32 is ${WIN32}")
+message("MSG: OS_NAME is ${OS_NAME}")
 
 # Set extension name here
 set(TARGET_NAME arrow)
@@ -19,6 +23,13 @@ else()
     set(OSX_ARCH_FLAG "")
 endif()
 
+if(WIN32)
+    set(BYPRODUCT_LIB_FILE arrow_static.lib)
+    set(DUCKDB_EXTRA_LINK_FLAGS arrow)
+else()
+    set(BYPRODUCT_LIB_FILE libarrow.a)
+endif()
+
 # Building Arrow
 include(ExternalProject)
 ExternalProject_Add(
@@ -27,7 +38,7 @@ ExternalProject_Add(
         GIT_TAG ea6875fd2a3ac66547a9a33c5506da94f3ff07f2
         PREFIX "${CMAKE_BINARY_DIR}/third_party/arrow"
         INSTALL_DIR "${CMAKE_BINARY_DIR}/third_party/arrow/install"
-        BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libarrow.a
+        BUILD_BYPRODUCTS <INSTALL_DIR>/lib/${BYPRODUCT_LIB_FILE}
         CONFIGURE_COMMAND
         ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${OSX_ARCH_FLAG}
         -DCMAKE_BUILD_TYPE=Release
@@ -49,23 +60,30 @@ ExternalProject_Add(
         -DARROW_WITH_ZSTD=OFF -DARROW_WITH_UCX=OFF -DARROW_WITH_UTF8PROC=OFF
         -DARROW_WITH_RE2=OFF <SOURCE_DIR>/cpp
         CMAKE_ARGS -Wno-dev
+        -DARROW_STATIC=1 # Add your preprocessor macro here
         UPDATE_COMMAND "")
 
 ExternalProject_Get_Property(ARROW_EP install_dir)
 add_library(arrow STATIC IMPORTED GLOBAL)
-set_target_properties(arrow PROPERTIES IMPORTED_LOCATION ${install_dir}/lib/libarrow.a)
+set_target_properties(arrow PROPERTIES IMPORTED_LOCATION ${install_dir}/lib/${BYPRODUCT_LIB_FILE})
 
 # create static library
 add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES})
 add_dependencies(${EXTENSION_NAME} ARROW_EP)
+if(WIN32)
+    target_compile_definitions(${EXTENSION_NAME} PRIVATE ARROW_STATIC)
+endif()
 target_link_libraries(${EXTENSION_NAME} PUBLIC arrow)
 target_include_directories(${EXTENSION_NAME} PRIVATE ${install_dir}/include)
 
 # create loadable extension
 set(PARAMETERS "-warnings")
+# target_link_libraries(${TARGET_NAME}_loadable_extension PUBLIC arrow_static)
 build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES})
 add_dependencies(${TARGET_NAME}_loadable_extension ARROW_EP)
-target_link_libraries(${TARGET_NAME}_loadable_extension arrow)
+if(WIN32)
+    target_compile_definitions(${TARGET_NAME}_loadable_extension PUBLIC ARROW_STATIC)
+endif()
 target_include_directories(${TARGET_NAME}_loadable_extension PRIVATE ${install_dir}/include)
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,11 @@ endif()
 
 if(WIN32)
     message("MSG: setting initial vars for WIN32")
-    set(BYPRODUCT_LIB_FILE arrow_static.lib)
-    set(DUCKDB_EXTRA_LINK_FLAGS arrow)
+    # set(BYPRODUCT_LIB_FILE "arrow_static.lib")
+    # set(DUCKDB_EXTRA_LINK_FLAGS arrow)
 else()
     message("MSG: setting initial vars for NOT windows")
-    set(BYPRODUCT_LIB_FILE libarrow.a)
+    set(BYPRODUCT_LIB_FILE "libarrow.a")
 endif()
 
 message("MSG: BYPRODUCT_LIB_FILE is: ${BYPRODUCT_LIB_FILE}")
@@ -42,7 +42,7 @@ ExternalProject_Add(
         GIT_TAG ea6875fd2a3ac66547a9a33c5506da94f3ff07f2
         PREFIX "${CMAKE_BINARY_DIR}/third_party/arrow"
         INSTALL_DIR "${CMAKE_BINARY_DIR}/third_party/arrow/install"
-        BUILD_BYPRODUCTS <INSTALL_DIR>/lib/${BYPRODUCT_LIB_FILE}
+        BUILD_BYPRODUCTS "<INSTALL_DIR>/lib/${BYPRODUCT_LIB_FILE}"
         CONFIGURE_COMMAND
         ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${OSX_ARCH_FLAG}
         -DCMAKE_BUILD_TYPE=Release
@@ -68,14 +68,14 @@ ExternalProject_Add(
 
 ExternalProject_Get_Property(ARROW_EP install_dir)
 add_library(arrow STATIC IMPORTED GLOBAL)
-set_target_properties(arrow PROPERTIES IMPORTED_LOCATION ${install_dir}/lib/${BYPRODUCT_LIB_FILE})
+set_target_properties(arrow PROPERTIES IMPORTED_LOCATION "${install_dir}/lib/${BYPRODUCT_LIB_FILE}")
 
 # create static library
 add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES})
 add_dependencies(${EXTENSION_NAME} ARROW_EP)
 if(WIN32)
     message("MSG: Adding compile macro to EXTENSION_NAME")
-    target_compile_definitions(${EXTENSION_NAME} PRIVATE ARROW_STATIC)
+    # target_compile_definitions(${EXTENSION_NAME} PRIVATE ARROW_STATIC)
 endif()
 target_link_libraries(${EXTENSION_NAME} PUBLIC arrow)
 target_include_directories(${EXTENSION_NAME} PRIVATE ${install_dir}/include)
@@ -87,7 +87,7 @@ build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES})
 add_dependencies(${TARGET_NAME}_loadable_extension ARROW_EP)
 if(WIN32)
     message("MSG: Adding compile def to TARGET_NAME")
-    target_compile_definitions(${TARGET_NAME}_loadable_extension PUBLIC ARROW_STATIC)
+    # target_compile_definitions(${TARGET_NAME}_loadable_extension PUBLIC ARROW_STATIC)
 endif()
 target_include_directories(${TARGET_NAME}_loadable_extension PRIVATE ${install_dir}/include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,15 @@ else()
 endif()
 
 if(WIN32)
+    message("MSG: setting initial vars for WIN32")
     set(BYPRODUCT_LIB_FILE arrow_static.lib)
     set(DUCKDB_EXTRA_LINK_FLAGS arrow)
 else()
+    message("MSG: setting initial vars for NOT windows")
     set(BYPRODUCT_LIB_FILE libarrow.a)
 endif()
+
+message("MSG: BYPRODUCT_LIB_FILE is: ${BYPRODUCT_LIB_FILE}")
 
 # Building Arrow
 include(ExternalProject)
@@ -60,7 +64,6 @@ ExternalProject_Add(
         -DARROW_WITH_ZSTD=OFF -DARROW_WITH_UCX=OFF -DARROW_WITH_UTF8PROC=OFF
         -DARROW_WITH_RE2=OFF <SOURCE_DIR>/cpp
         CMAKE_ARGS -Wno-dev
-        -DARROW_STATIC=1 # Add your preprocessor macro here
         UPDATE_COMMAND "")
 
 ExternalProject_Get_Property(ARROW_EP install_dir)
@@ -71,6 +74,7 @@ set_target_properties(arrow PROPERTIES IMPORTED_LOCATION ${install_dir}/lib/${BY
 add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES})
 add_dependencies(${EXTENSION_NAME} ARROW_EP)
 if(WIN32)
+    message("MSG: Adding compile macro to EXTENSION_NAME")
     target_compile_definitions(${EXTENSION_NAME} PRIVATE ARROW_STATIC)
 endif()
 target_link_libraries(${EXTENSION_NAME} PUBLIC arrow)
@@ -82,6 +86,7 @@ set(PARAMETERS "-warnings")
 build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES})
 add_dependencies(${TARGET_NAME}_loadable_extension ARROW_EP)
 if(WIN32)
+    message("MSG: Adding compile def to TARGET_NAME")
     target_compile_definitions(${TARGET_NAME}_loadable_extension PUBLIC ARROW_STATIC)
 endif()
 target_include_directories(${TARGET_NAME}_loadable_extension PRIVATE ${install_dir}/include)


### PR DESCRIPTION
Added the Windows.yml based on the one from the main branch from a couple weeks ago. Updated CMakeLists with Arrow’s windows instructions so it compiles. See https://github.com/apache/arrow/blob/main/docs/source/developers/cpp/windows.rst the sections on “Windows dependency resolution issues” and “statically linking to arrow on windows”. CI ran fine on my fork but let me know if i should check anything else