### PR TITLE
First release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "duckdb"]
-	path = duckdb
-	url = https://github.com/drin/duckdb
-	branch = coop-decomp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "duckdb"]
 	path = duckdb
-	url = https://github.com/duckdb/duckdb
-	branch = main
+	url = https://github.com/drin/duckdb
+	branch = coop-decomp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25.1)
+cmake_minimum_required(VERSION 3.5)
 
 # Set extension name here
 set(TARGET_NAME arrow)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,12 @@ set(EXTENSION_NAME ${TARGET_NAME}_extension)
 project(${TARGET_NAME})
 include_directories(src/include)
 
-set(EXTENSION_SOURCES src/arrow_extension.cpp src/arrow_stream_buffer.cpp
-                      src/arrow_scan_ipc.cpp src/arrow_to_ipc.cpp)
+set(EXTENSION_SOURCES
+    src/arrow_extension.cpp
+    src/arrow_stream_buffer.cpp
+    src/arrow_readers.cpp
+    src/arrow_scan_ipc.cpp
+    src/arrow_to_ipc.cpp)
 
 if(NOT "${OSX_BUILD_ARCH}" STREQUAL "")
   set(OSX_ARCH_FLAG -DCMAKE_OSX_ARCHITECTURES=${OSX_BUILD_ARCH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,13 +20,13 @@ else()
   set(OSX_ARCH_FLAG "")
 endif()
 
-# Building Arrow (6a0414b is for tag apache-arrow-18.1.0)
+# Building Arrow (272715f is for tag apache-arrow-19.0.1)
 set(CMAKE_CXX_STANDARD 17)
 include(ExternalProject)
 ExternalProject_Add(
         ARROW_EP
         GIT_REPOSITORY "https://github.com/apache/arrow"
-        GIT_TAG 6a0414bd9a91e890ec6a45369bf61f405180628c
+        GIT_TAG 272715f6df2a042d69881ffa03d5078c58e4b345
         PREFIX "${CMAKE_BINARY_DIR}/third_party/arrow"
         INSTALL_DIR "${CMAKE_BINARY_DIR}/third_party/arrow/install"
         BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libarrow.a
@@ -46,6 +46,7 @@ ExternalProject_Add(
                          -DARROW_POSITION_INDEPENDENT_CODE=ON
                          -DARROW_SIMD_LEVEL=NONE
                          -DARROW_JEMALLOC=OFF
+                         -DARROW_MIMALLOC=OFF
                          -DARROW_IPC=ON
                          -DARROW_JSON=OFF
                          -DARROW_ORC=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,13 +20,13 @@ else()
   set(OSX_ARCH_FLAG "")
 endif()
 
-# Building Arrow (6a2e19a is for tag apache-arrow-17.0.0)
+# Building Arrow (6a0414b is for tag apache-arrow-18.1.0)
 set(CMAKE_CXX_STANDARD 17)
 include(ExternalProject)
 ExternalProject_Add(
         ARROW_EP
         GIT_REPOSITORY "https://github.com/apache/arrow"
-        GIT_TAG 6a2e19a852b367c72d7b12da4d104456491ed8b7
+        GIT_TAG 6a0414bd9a91e890ec6a45369bf61f405180628c
         PREFIX "${CMAKE_BINARY_DIR}/third_party/arrow"
         INSTALL_DIR "${CMAKE_BINARY_DIR}/third_party/arrow/install"
         BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libarrow.a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 # Set extension name here
 set(TARGET_NAME arrow)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.25.1)
 
 # Set extension name here
 set(TARGET_NAME arrow)
@@ -16,37 +16,73 @@ else()
   set(OSX_ARCH_FLAG "")
 endif()
 
-# Building Arrow
+# Building Arrow (e03105e is for tag apache-arrow-15.0.2)
+set(CMAKE_CXX_STANDARD 17)
 include(ExternalProject)
 ExternalProject_Add(
-  ARROW_EP
-  GIT_REPOSITORY "https://github.com/apache/arrow"
-  GIT_TAG ea6875fd2a3ac66547a9a33c5506da94f3ff07f2
-  PREFIX "${CMAKE_BINARY_DIR}/third_party/arrow"
-  INSTALL_DIR "${CMAKE_BINARY_DIR}/third_party/arrow/install"
-  BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libarrow.a
-  CONFIGURE_COMMAND
-    ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${OSX_ARCH_FLAG}
-    -DCMAKE_BUILD_TYPE=Release
-    -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/third_party/arrow/install
-    -DCMAKE_INSTALL_LIBDIR=lib -DARROW_BUILD_STATIC=ON -DARROW_BUILD_SHARED=OFF
-    -DARROW_NO_DEPRECATED_API=ON -DARROW_POSITION_INDEPENDENT_CODE=ON
-    -DARROW_SIMD_LEVEL=NONE -DARROW_ENABLE_TIMING_TESTS=OFF -DARROW_IPC=ON
-    -DARROW_JEMALLOC=OFF -DARROW_DEPENDENCY_SOURCE=BUNDLED
-    -DARROW_VERBOSE_THIRDPARTY_BUILD=OFF -DARROW_DEPENDENCY_USE_SHARED=OFF
-    -DARROW_BOOST_USE_SHARED=OFF -DARROW_BROTLI_USE_SHARED=OFF
-    -DARROW_BZ2_USE_SHARED=OFF -DARROW_GFLAGS_USE_SHARED=OFF
-    -DARROW_GRPC_USE_SHARED=OFF -DARROW_JEMALLOC_USE_SHARED=OFF
-    -DARROW_LZ4_USE_SHARED=OFF -DARROW_OPENSSL_USE_SHARED=OFF
-    -DARROW_PROTOBUF_USE_SHARED=OFF -DARROW_SNAPPY_USE_SHARED=OFF
-    -DARROW_THRIFT_USE_SHARED=OFF -DARROW_UTF8PROC_USE_SHARED=OFF
-    -DARROW_ZSTD_USE_SHARED=OFF -DARROW_USE_GLOG=OFF -DARROW_WITH_BACKTRACE=OFF
-    -DARROW_WITH_OPENTELEMETRY=OFF -DARROW_WITH_BROTLI=OFF -DARROW_WITH_BZ2=OFF
-    -DARROW_WITH_LZ4=OFF -DARROW_WITH_SNAPPY=OFF -DARROW_WITH_ZLIB=OFF
-    -DARROW_WITH_ZSTD=OFF -DARROW_WITH_UCX=OFF -DARROW_WITH_UTF8PROC=OFF
-    -DARROW_WITH_RE2=OFF <SOURCE_DIR>/cpp
-  CMAKE_ARGS -Wno-dev
-  UPDATE_COMMAND "")
+        ARROW_EP
+        GIT_REPOSITORY "https://github.com/apache/arrow"
+        GIT_TAG 6a2e19a852b367c72d7b12da4d104456491ed8b7
+        PREFIX "${CMAKE_BINARY_DIR}/third_party/arrow"
+        INSTALL_DIR "${CMAKE_BINARY_DIR}/third_party/arrow/install"
+        BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libarrow.a
+        CONFIGURE_COMMAND
+        ${CMAKE_COMMAND} -G${CMAKE_GENERATOR}
+                           ${OSX_ARCH_FLAG}
+                         -DCMAKE_BUILD_TYPE=Release
+                         -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/third_party/arrow/install
+                         -DCMAKE_INSTALL_LIBDIR=lib
+                         -DARROW_BUILD_STATIC=ON
+                         -DARROW_BUILD_SHARED=OFF
+                         -DARROW_DEPENDENCY_USE_SHARED=OFF
+                         -DARROW_DEPENDENCY_SOURCE=BUNDLED
+                         -DARROW_VERBOSE_THIRDPARTY_BUILD=OFF
+                         -DARROW_ENABLE_TIMING_TESTS=OFF
+                         -DARROW_NO_DEPRECATED_API=ON
+                         -DARROW_POSITION_INDEPENDENT_CODE=ON
+                         -DARROW_SIMD_LEVEL=NONE
+                         -DARROW_JEMALLOC=OFF
+                         -DARROW_IPC=ON
+                         -DARROW_JSON=OFF
+                         -DARROW_ORC=OFF
+                         -DARROW_CSV=OFF
+                         -DARROW_PARQUET=OFF
+                         -DARROW_SUBSTRAIT=OFF
+                         -DARROW_ACERO=OFF
+                         -DARROW_COMPUTE=OFF
+                         -DARROW_DATASET=OFF
+                         -DARROW_FILESYSTEM=OFF
+                         -DARROW_FLIGHT=OFF
+                         -DARROW_FLIGHT_SQL=OFF
+                         -DARROW_GANDIVA=OFF
+                         -DARROW_USE_GLOG=OFF
+                         -DARROW_WITH_BACKTRACE=OFF
+                         -DARROW_WITH_OPENTELEMETRY=OFF
+                         -DARROW_WITH_UCX=OFF
+                         -DARROW_WITH_RE2=OFF
+                         -DARROW_WITH_BROTLI=OFF
+                         -DARROW_WITH_BZ2=OFF
+                         -DARROW_WITH_LZ4=OFF
+                         -DARROW_WITH_SNAPPY=OFF
+                         -DARROW_WITH_ZLIB=OFF
+                         -DARROW_WITH_ZSTD=OFF
+                         -DARROW_WITH_UTF8PROC=OFF
+                         -DARROW_BOOST_USE_SHARED=OFF
+                         -DARROW_GFLAGS_USE_SHARED=OFF
+                         -DARROW_GRPC_USE_SHARED=OFF
+                         -DARROW_JEMALLOC_USE_SHARED=OFF
+                         -DARROW_OPENSSL_USE_SHARED=OFF
+                         -DARROW_PROTOBUF_USE_SHARED=OFF
+                         -DARROW_THRIFT_USE_SHARED=OFF
+                         -DARROW_BROTLI_USE_SHARED=OFF
+                         -DARROW_BZ2_USE_SHARED=OFF
+                         -DARROW_LZ4_USE_SHARED=OFF
+                         -DARROW_SNAPPY_USE_SHARED=OFF
+                         -DARROW_ZSTD_USE_SHARED=OFF
+                         -DARROW_UTF8PROC_USE_SHARED=OFF
+                         <SOURCE_DIR>/cpp
+        CMAKE_ARGS -Wno-dev
+        UPDATE_COMMAND "")
 
 ExternalProject_Get_Property(ARROW_EP install_dir)
 add_library(arrow STATIC IMPORTED GLOBAL)
@@ -76,8 +112,8 @@ endif()
 target_include_directories(${TARGET_NAME}_loadable_extension
                            PRIVATE ${install_dir}/include)
 
-install(
-  TARGETS ${EXTENSION_NAME}
-  EXPORT "${DUCKDB_EXPORT_SET}"
-  LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
-  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
+install(TARGETS ${EXTENSION_NAME}
+        EXPORT "${DUCKDB_EXPORT_SET}"
+        LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
+        ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ else()
   set(OSX_ARCH_FLAG "")
 endif()
 
-# Building Arrow (e03105e is for tag apache-arrow-15.0.2)
+# Building Arrow (6a2e19a is for tag apache-arrow-17.0.0)
 set(CMAKE_CXX_STANDARD 17)
 include(ExternalProject)
 ExternalProject_Add(

--- a/src/arrow_extension.cpp
+++ b/src/arrow_extension.cpp
@@ -6,39 +6,41 @@
 #include "arrow_to_ipc.hpp"
 
 #include "duckdb.hpp"
+
 #ifndef DUCKDB_AMALGAMATION
-#include "duckdb/common/arrow/result_arrow_wrapper.hpp"
-#include "duckdb/common/arrow/arrow_appender.hpp"
-#include "duckdb/common/arrow/arrow_converter.hpp"
-#include "duckdb/main/extension_util.hpp"
-#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
-#include "duckdb/function/table/arrow.hpp"
+  #include "duckdb/common/arrow/result_arrow_wrapper.hpp"
+  #include "duckdb/common/arrow/arrow_appender.hpp"
+  #include "duckdb/common/arrow/arrow_converter.hpp"
+  #include "duckdb/main/extension_util.hpp"
+  #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+  #include "duckdb/function/table/arrow.hpp"
 #endif
 
+
+// ------------------------------
+// Load extension automatically (I think)
 namespace duckdb {
 
-static void LoadInternal(DatabaseInstance &instance) {
-  ExtensionUtil::RegisterFunction(instance, ToArrowIPCFunction::GetFunction());
-  ExtensionUtil::RegisterFunction(instance,
-                                  ArrowIPCTableFunction::GetFunction());
-}
+  static void LoadInternal(DatabaseInstance &instance) {
+    ExtensionUtil::RegisterFunction(instance,    ToArrowIPCFunction::GetFunction());
+    ExtensionUtil::RegisterFunction(instance, ArrowIPCTableFunction::GetFunction());
+  }
 
-void ArrowExtension::Load(DuckDB &db) { LoadInternal(*db.instance); }
-std::string ArrowExtension::Name() { return "arrow"; }
+  void        ArrowExtension::Load(DuckDB &db) { LoadInternal(*db.instance); }
+  std::string ArrowExtension::Name()           { return "arrow"; }
 
-} // namespace duckdb
+} // namespace: duckdb
+
 
 extern "C" {
+  DUCKDB_EXTENSION_API
+  void arrow_init(duckdb::DatabaseInstance &db) { LoadInternal(db); }
 
-DUCKDB_EXTENSION_API void arrow_init(duckdb::DatabaseInstance &db) {
-  LoadInternal(db);
+  DUCKDB_EXTENSION_API
+  const char *arrow_version() { return duckdb::DuckDB::LibraryVersion(); }
 }
 
-DUCKDB_EXTENSION_API const char *arrow_version() {
-  return duckdb::DuckDB::LibraryVersion();
-}
-}
 
 #ifndef DUCKDB_EXTENSION_MAIN
-#error DUCKDB_EXTENSION_MAIN not defined
+  #error DUCKDB_EXTENSION_MAIN not defined
 #endif

--- a/src/arrow_extension.cpp
+++ b/src/arrow_extension.cpp
@@ -21,9 +21,21 @@
 // Load extension automatically (I think)
 namespace duckdb {
 
-  static void LoadInternal(DatabaseInstance &instance) {
-    ExtensionUtil::RegisterFunction(instance,    ToArrowIPCFunction::GetFunction());
-    ExtensionUtil::RegisterFunction(instance, ArrowIPCTableFunction::GetFunction());
+  static void LoadInternal(DatabaseInstance& instance) {
+    // Table Functions for converting to Arrow IPC
+    ExtensionUtil::RegisterFunction(instance, ToArrowIPCFunction::GetFunction());
+
+    // Table Functions for converting from Arrow IPC
+
+    // scans IPC buffers directly
+    ExtensionUtil::RegisterFunction(
+      instance, ArrowIPCTableFunction::GetFunctionScanIPC()
+    );
+
+    // scans arrow stream format from files
+    ExtensionUtil::RegisterFunction(
+      instance, ArrowIPCTableFunction::GetFunctionScanArrows()
+    );
   }
 
   void        ArrowExtension::Load(DuckDB &db) { LoadInternal(*db.instance); }

--- a/src/arrow_readers.cpp
+++ b/src/arrow_readers.cpp
@@ -1,0 +1,158 @@
+// ------------------------------
+// License
+//
+// Copyright 2024 Aldrin Montana
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// ------------------------------
+// Dependencies
+
+#include "arrow_readers.hpp"
+
+
+// ------------------------------
+// Reader implementations
+// TODO: eventually migrate these to prefer internal duckdb types
+
+namespace duckdb {
+
+  // Anonymous namespace for internal functions
+  namespace {
+
+    /** Given a file path, return an arrow::ReadableFile. */
+    arrow::Result<std::shared_ptr<arrow::io::ReadableFile>>
+    HandleForIPCFile(const std::string &path_as_uri) {
+      std::cout << "Creating handle for arrow IPC-formatted file: "
+                << path_as_uri
+                << std::endl
+      ;
+
+      // use the `FileSystem` instance to open a handle to the file
+      return arrow::io::ReadableFile::Open(path_as_uri);
+    }
+
+    /** Given a file path, create a RecordBatchStreamReader. */
+    arrow::Result<std::shared_ptr<arrow::ipc::RecordBatchStreamReader>>
+    ReaderForIPCStream(const std::string &path_as_uri) {
+      std::cout << "Creating reader for IPC stream" << std::endl;
+
+      // use the `FileSystem` instance to open a handle to the file
+      ARROW_ASSIGN_OR_RAISE(auto input_file_handle, HandleForIPCFile(path_as_uri));
+
+      // read from the handle using `RecordBatchStreamReader`
+      return arrow::ipc::RecordBatchStreamReader::Open(input_file_handle);
+    }
+
+    /** Given a file path, create a RecordBatchFileReader. */
+    arrow::Result<std::shared_ptr<arrow::ipc::RecordBatchFileReader>>
+    ReaderForIPCFile(const std::string &path_as_uri) {
+      std::cout << "Creating reader for IPC file" << std::endl;
+
+      // use the `FileSystem` instance to open a handle to the file
+      ARROW_ASSIGN_OR_RAISE(auto input_file_handle, HandleForIPCFile(path_as_uri));
+
+      // read from the handle using `RecordBatchStreamReader`
+      return arrow::ipc::RecordBatchFileReader::Open(input_file_handle);
+    }
+
+  } // anonymous namespace: mohair::<anonymous>
+
+
+  // >> Implementations that wrap internal functions from the anonymous namespace
+  //! Given a file path to an Arrow IPC stream, return the data as a buffer.
+  arrow::Result<std::shared_ptr<arrow::Buffer>>
+  BufferFromIPCStream(const std::string& path_to_file) {
+    // use the `FileSystem` instance to open a handle to the file
+    ARROW_ASSIGN_OR_RAISE(auto arrow_fhandle, HandleForIPCFile(path_to_file));
+
+    // get the size of the file handle (arrow::io::RandomAccessFile) and read it whole
+    ARROW_ASSIGN_OR_RAISE(auto  arrow_fsize, arrow_fhandle->GetSize());
+    ARROW_ASSIGN_OR_RAISE(auto arrow_buffer, arrow_fhandle->ReadAt(0, arrow_fsize));
+
+    if (not arrow_buffer->is_cpu()) {
+      return arrow::Status::Invalid(
+        "Read IPC stream file into memory but it is not CPU-accessible"
+      );
+    }
+
+    return arrow_buffer;
+  }
+
+  /*
+  //! Given a file path to an Arrow IPC stream, return a Table.
+  arrow::Result<std::shared_ptr<Table>>
+  ReadIPCStream(const std::string& path_to_file) {
+    // Declares and initializes `batch_reader`
+    ARROW_ASSIGN_OR_RAISE(auto batch_reader, ReaderForIPCStream(path_to_file));
+
+    return arrow::Table::FromRecordBatchReader(batch_reader.get());
+  }
+
+  //! Given a file path to an Arrow IPC file, return a Table.
+  arrow::Result<std::shared_ptr<Table>>
+  ReadIPCFile(const std::string& path_to_file) {
+    // Declares and initializes `ipc_file_reader`
+    ARROW_ASSIGN_OR_RAISE(auto ipc_file_reader, ReaderForIPCFile(path_to_file));
+
+    // Based on RecordBatchFileReader::ToTable (Arrow >12.0.1)
+    // https://github.com/apache/arrow/blob/main/cpp/src/arrow/ipc/reader.h#L236-L237
+    RecordBatchVector batches;
+
+    const auto batch_count = ipc_file_reader->num_record_batches();
+    for (int batch_ndx = 0; batch_ndx < batch_count; ++batch_ndx) {
+      ARROW_ASSIGN_OR_RAISE(auto batch, ipc_file_reader->ReadRecordBatch(batch_ndx));
+      batches.emplace_back(batch);
+    }
+
+    return arrow::Table::FromRecordBatches(ipc_file_reader->schema(), batches);
+  }
+  */
+
+  // >> Implementations that prefer internal duckdb types
+  arrow::Status
+  ConsumeArrowStream( std::shared_ptr<ArrowIPCStreamBuffer> ipc_buffer
+                     ,vector<duckdb::Value> input_buffers) {
+    // Decoder consumes each IPC buffer and the `ipc_buffer` listens for its events
+    auto stream_decoder = make_uniq<ArrowIPCDec>(std::move(ipc_buffer));
+
+    for (auto& input_buffer : input_buffers) {
+      // Each "buffer" is a pointer to data and a buffer size
+      auto     unpacked    = StructValue::GetChildren(input_buffer);
+      uint64_t buffer_ptr  = unpacked[0].GetValue<uint64_t>();
+      uint64_t buffer_size = unpacked[1].GetValue<uint64_t>();
+
+      auto decode_status = stream_decoder->Consume(
+        (const uint8_t*) buffer_ptr, buffer_size
+      );
+
+      if (!decode_status.ok()) { return decode_status; }
+    }
+
+    return arrow::Status::OK();
+  }
+
+
+  Value ValueForIPCBuffer(arrow::Buffer& ipc_buffer) {
+    // Place values into a child_list_t<type>
+    child_list_t<Value> struct_vals {
+       { "ptr" , Value::UBIGINT((uintptr_t) ipc_buffer.mutable_data()) }
+      ,{ "size", Value::UBIGINT((uint64_t)  ipc_buffer.size())         }
+    };
+
+    // Call the STRUCT builder function
+    return Value::STRUCT(struct_vals);
+  }
+
+} // namespace: duckdb

--- a/src/arrow_readers.cpp
+++ b/src/arrow_readers.cpp
@@ -34,11 +34,6 @@ namespace duckdb {
     /** Given a file path, return an arrow::ReadableFile. */
     arrow::Result<std::shared_ptr<arrow::io::ReadableFile>>
     HandleForIPCFile(const std::string &path_as_uri) {
-      std::cout << "Creating handle for arrow IPC-formatted file: "
-                << path_as_uri
-                << std::endl
-      ;
-
       // use the `FileSystem` instance to open a handle to the file
       return arrow::io::ReadableFile::Open(path_as_uri);
     }
@@ -46,8 +41,6 @@ namespace duckdb {
     /** Given a file path, create a RecordBatchStreamReader. */
     arrow::Result<std::shared_ptr<arrow::ipc::RecordBatchStreamReader>>
     ReaderForIPCStream(const std::string &path_as_uri) {
-      std::cout << "Creating reader for IPC stream" << std::endl;
-
       // use the `FileSystem` instance to open a handle to the file
       ARROW_ASSIGN_OR_RAISE(auto input_file_handle, HandleForIPCFile(path_as_uri));
 
@@ -58,8 +51,6 @@ namespace duckdb {
     /** Given a file path, create a RecordBatchFileReader. */
     arrow::Result<std::shared_ptr<arrow::ipc::RecordBatchFileReader>>
     ReaderForIPCFile(const std::string &path_as_uri) {
-      std::cout << "Creating reader for IPC file" << std::endl;
-
       // use the `FileSystem` instance to open a handle to the file
       ARROW_ASSIGN_OR_RAISE(auto input_file_handle, HandleForIPCFile(path_as_uri));
 

--- a/src/arrow_scan_ipc.cpp
+++ b/src/arrow_scan_ipc.cpp
@@ -175,7 +175,7 @@ namespace duckdb {
 
     scan_arrow_ipc_func.cardinality = ArrowTableFunction::ArrowScanCardinality;
     // TODO: implement
-    scan_arrow_ipc_func.get_batch_index     = ArrowTableFunction::ArrowGetBatchIndex;
+    scan_arrow_ipc_func.get_partition_data  = ArrowTableFunction::ArrowGetPartitionData;
     scan_arrow_ipc_func.projection_pushdown = true;
     scan_arrow_ipc_func.filter_pushdown     = false;
 
@@ -196,7 +196,7 @@ namespace duckdb {
 
     tfn_scan_arrows.cardinality = ArrowTableFunction::ArrowScanCardinality;
     // TODO: implement
-    tfn_scan_arrows.get_batch_index     = ArrowTableFunction::ArrowGetBatchIndex;
+    tfn_scan_arrows.get_partition_data  = ArrowTableFunction::ArrowGetPartitionData;
     tfn_scan_arrows.projection_pushdown = true;
     tfn_scan_arrows.filter_pushdown     = false;
 

--- a/src/arrow_stream_buffer.cpp
+++ b/src/arrow_stream_buffer.cpp
@@ -3,106 +3,112 @@
 #include <iostream>
 #include <memory>
 
-/// File copied from
-/// https://github.com/duckdb/duckdb-wasm/blob/0ad10e7db4ef4025f5f4120be37addc4ebe29618/lib/src/arrow_stream_buffer.cc
+
 namespace duckdb {
 
-/// Constructor
-ArrowIPCStreamBuffer::ArrowIPCStreamBuffer()
+  // >> ArrowIPCStreamBuffer implementations
+
+  ArrowIPCStreamBuffer::ArrowIPCStreamBuffer()
     : schema_(nullptr), batches_(), is_eos_(false) {}
-/// Decoded a schema
-arrow::Status
-ArrowIPCStreamBuffer::OnSchemaDecoded(std::shared_ptr<arrow::Schema> s) {
-  schema_ = s;
-  return arrow::Status::OK();
-}
-/// Decoded a record batch
-arrow::Status ArrowIPCStreamBuffer::OnRecordBatchDecoded(
-    std::shared_ptr<arrow::RecordBatch> batch) {
-  batches_.push_back(batch);
-  return arrow::Status::OK();
-}
-/// Reached end of stream
-arrow::Status ArrowIPCStreamBuffer::OnEOS() {
-  is_eos_ = true;
-  return arrow::Status::OK();
-}
 
-/// Constructor
-ArrowIPCStreamBufferReader::ArrowIPCStreamBufferReader(
-    std::shared_ptr<ArrowIPCStreamBuffer> buffer)
-    : buffer_(buffer), next_batch_id_(0) {}
-
-/// Get the schema
-std::shared_ptr<arrow::Schema> ArrowIPCStreamBufferReader::schema() const {
-  return buffer_->schema();
-}
-/// Read the next record batch in the stream. Return null for batch when
-/// reaching end of stream
-arrow::Status ArrowIPCStreamBufferReader::ReadNext(
-    std::shared_ptr<arrow::RecordBatch> *batch) {
-  if (next_batch_id_ >= buffer_->batches().size()) {
-    *batch = nullptr;
+  //! Event handlers (arrow::ipc::Listener interface)
+  arrow::Status
+  ArrowIPCStreamBuffer::OnSchemaDecoded(std::shared_ptr<arrow::Schema> s) {
+    schema_ = s;
     return arrow::Status::OK();
   }
-  *batch = buffer_->batches()[next_batch_id_++];
-  return arrow::Status::OK();
-}
 
-/// Arrow array stream factory function
-duckdb::unique_ptr<duckdb::ArrowArrayStreamWrapper>
-ArrowIPCStreamBufferReader::CreateStream(uintptr_t buffer_ptr,
-                                         ArrowStreamParameters &parameters) {
-  assert(buffer_ptr != 0);
-  auto buffer =
-      reinterpret_cast<std::shared_ptr<ArrowIPCStreamBuffer> *>(buffer_ptr);
-  auto reader = std::make_shared<ArrowIPCStreamBufferReader>(*buffer);
-
-  // Create arrow stream
-  auto stream_wrapper = duckdb::make_uniq<duckdb::ArrowArrayStreamWrapper>();
-  stream_wrapper->arrow_array_stream.release = nullptr;
-  auto maybe_ok = arrow::ExportRecordBatchReader(
-      reader, &stream_wrapper->arrow_array_stream);
-  if (!maybe_ok.ok()) {
-    if (stream_wrapper->arrow_array_stream.release) {
-      stream_wrapper->arrow_array_stream.release(
-          &stream_wrapper->arrow_array_stream);
-    }
-    return nullptr;
+  arrow::Status
+  ArrowIPCStreamBuffer::OnRecordBatchDecoded(std::shared_ptr<arrow::RecordBatch> batch) {
+    batches_.push_back(std::move(batch));
+    return arrow::Status::OK();
   }
 
-  // Release the stream
-  return stream_wrapper;
-}
-
-void ArrowIPCStreamBufferReader::GetSchema(uintptr_t buffer_ptr,
-                                           duckdb::ArrowSchemaWrapper &schema) {
-  assert(buffer_ptr != 0);
-  auto buffer =
-      reinterpret_cast<std::shared_ptr<ArrowIPCStreamBuffer> *>(buffer_ptr);
-  auto reader = std::make_shared<ArrowIPCStreamBufferReader>(*buffer);
-
-  // Create arrow stream
-  auto stream_wrapper = duckdb::make_uniq<duckdb::ArrowArrayStreamWrapper>();
-  stream_wrapper->arrow_array_stream.release = nullptr;
-  auto maybe_ok = arrow::ExportRecordBatchReader(
-      reader, &stream_wrapper->arrow_array_stream);
-  if (!maybe_ok.ok()) {
-    if (stream_wrapper->arrow_array_stream.release) {
-      stream_wrapper->arrow_array_stream.release(
-          &stream_wrapper->arrow_array_stream);
-    }
-    return;
+  arrow::Status
+  ArrowIPCStreamBuffer::OnEOS() {
+    is_eos_ = true;
+    return arrow::Status::OK();
   }
 
-  // Pass ownership to caller
-  stream_wrapper->arrow_array_stream.get_schema(
-      &stream_wrapper->arrow_array_stream, &schema.arrow_schema);
-}
 
-/// Constructor
-BufferingArrowIPCStreamDecoder::BufferingArrowIPCStreamDecoder(
-    std::shared_ptr<ArrowIPCStreamBuffer> buffer)
-    : arrow::ipc::StreamDecoder(buffer), buffer_(buffer) {}
+  // >> ArrowRecordBatchReader implementations
+
+  ArrowRecordBatchReader::ArrowRecordBatchReader(std::shared_ptr<ArrowIPCStreamBuffer> buffer)
+      : buffer_(buffer), next_batch_id_(0) {}
+
+  std::shared_ptr<arrow::Schema>
+  ArrowRecordBatchReader::schema() const { return buffer_->schema(); }
+
+  //! Read the next record batch in the stream. Sets *batch to null at end of stream
+  arrow::Status
+  ArrowRecordBatchReader::ReadNext(std::shared_ptr<arrow::RecordBatch>* batch) {
+    if (next_batch_id_ >= buffer_->batches().size()) {
+      *batch = nullptr;
+    }
+
+    else {
+      *batch = buffer_->batches()[next_batch_id_++];
+    }
+
+    return arrow::Status::OK();
+  }
+
+  //! Creates a C stream on the input IPC buffer
+  duckdb::unique_ptr<duckdb::ArrowArrayStreamWrapper>
+  CStreamForIPCBuffer(uintptr_t buffer_ptr, ArrowStreamParameters &parameters) {
+    assert(buffer_ptr != 0);
+
+    auto buffer = reinterpret_cast<std::shared_ptr<ArrowIPCStreamBuffer>*>(buffer_ptr);
+    auto reader = std::make_shared<ArrowRecordBatchReader>(*buffer);
+
+    // Create arrow stream
+    auto stream_wrapper = duckdb::make_uniq<duckdb::ArrowArrayStreamWrapper>();
+    stream_wrapper->arrow_array_stream.release = nullptr;
+
+    auto export_status = arrow::ExportRecordBatchReader(
+      reader, &stream_wrapper->arrow_array_stream
+    );
+
+    if (!export_status.ok()) {
+      if (stream_wrapper->arrow_array_stream.release) {
+        stream_wrapper->arrow_array_stream.release(&stream_wrapper->arrow_array_stream);
+      }
+
+      return nullptr;
+    }
+
+    // Release the stream
+    return stream_wrapper;
+  }
+
+  //! Sets Arrow schema (C data interface) from input IPC buffer
+  void SchemaFromIPCBuffer(uintptr_t buffer_ptr, duckdb::ArrowSchemaWrapper &schema) {
+    assert(buffer_ptr != 0);
+
+    auto buffer = reinterpret_cast<std::shared_ptr<ArrowIPCStreamBuffer>*>(buffer_ptr);
+    auto reader = std::make_shared<ArrowRecordBatchReader>(*buffer);
+
+    // Export RecordBatchReader to C data interface so we get an `ArrowSchema`
+    auto stream_wrapper = duckdb::make_uniq<duckdb::ArrowArrayStreamWrapper>();
+    stream_wrapper->arrow_array_stream.release = nullptr;
+
+    auto export_status = arrow::ExportRecordBatchReader(
+      reader, &stream_wrapper->arrow_array_stream
+    );
+
+    if (!export_status.ok()) {
+      if (stream_wrapper->arrow_array_stream.release) {
+        stream_wrapper->arrow_array_stream.release(&stream_wrapper->arrow_array_stream);
+      }
+
+      return;
+    }
+
+    // Set the `arrow_schema` attribute of ArrowSchemaWrapper (also passes ownership)
+    stream_wrapper->arrow_array_stream.get_schema(
+       &stream_wrapper->arrow_array_stream
+      ,&schema.arrow_schema
+    );
+  }
 
 } // namespace duckdb

--- a/src/arrow_stream_buffer.cpp
+++ b/src/arrow_stream_buffer.cpp
@@ -82,7 +82,7 @@ namespace duckdb {
 
   //! Sets Arrow schema (C data interface) from input IPC buffer
   void SchemaFromIPCBuffer( std::shared_ptr<ArrowIPCStreamBuffer> buffer
-                           ,duckdb::ArrowSchemaWrapper&      schema) {
+                           ,duckdb::ArrowSchemaWrapper&           schema) {
     auto reader = std::make_shared<ArrowRecordBatchReader>(buffer);
 
     // Export RecordBatchReader to C data interface so we get an `ArrowSchema`

--- a/src/arrow_stream_buffer.cpp
+++ b/src/arrow_stream_buffer.cpp
@@ -81,7 +81,7 @@ namespace duckdb {
   }
 
   //! Sets Arrow schema (C data interface) from input IPC buffer
-  void SchemaFromIPCBuffer( shared_ptr<ArrowIPCStreamBuffer> buffer
+  void SchemaFromIPCBuffer( std::shared_ptr<ArrowIPCStreamBuffer> buffer
                            ,duckdb::ArrowSchemaWrapper&      schema) {
     auto reader = std::make_shared<ArrowRecordBatchReader>(buffer);
 

--- a/src/arrow_to_ipc.cpp
+++ b/src/arrow_to_ipc.cpp
@@ -32,8 +32,8 @@ namespace duckdb {
   struct ToArrowIpcFunctionData: public TableFunctionData {
     ToArrowIpcFunctionData() {}
 
-    shared_ptr<arrow::Schema> schema;
-    idx_t                     chunk_size;
+    std::shared_ptr<arrow::Schema> schema;
+    idx_t                          chunk_size;
   };
 
   struct ToArrowIpcGlobalState: public GlobalTableFunctionState {
@@ -90,7 +90,7 @@ namespace duckdb {
 
     result->schema = arrow::ImportSchema(&schema).ValueOrDie();
 
-    return std::move(result);
+    return result;
   }
 
   OperatorResultType ToArrowIPCFunction::Function( ExecutionContext&   context

--- a/src/arrow_to_ipc.cpp
+++ b/src/arrow_to_ipc.cpp
@@ -29,112 +29,132 @@
 
 namespace duckdb {
 
-struct ToArrowIpcFunctionData : public TableFunctionData {
-  ToArrowIpcFunctionData() {}
-  std::shared_ptr<arrow::Schema> schema;
-  idx_t chunk_size;
-};
+  struct ToArrowIpcFunctionData: public TableFunctionData {
+    ToArrowIpcFunctionData() {}
 
-struct ToArrowIpcGlobalState : public GlobalTableFunctionState {
-  ToArrowIpcGlobalState() : sent_schema(false) {}
-  atomic<bool> sent_schema;
-  mutex lock;
-};
+    shared_ptr<arrow::Schema> schema;
+    idx_t                     chunk_size;
+  };
 
-struct ToArrowIpcLocalState : public LocalTableFunctionState {
-  unique_ptr<ArrowAppender> appender;
-  idx_t current_count = 0;
-  bool checked_schema = false;
-};
+  struct ToArrowIpcGlobalState: public GlobalTableFunctionState {
+    ToArrowIpcGlobalState(): sent_schema(false) {}
 
-unique_ptr<LocalTableFunctionState>
-ToArrowIPCFunction::InitLocal(ExecutionContext &context,
-                              TableFunctionInitInput &input,
-                              GlobalTableFunctionState *global_state) {
-  return make_uniq<ToArrowIpcLocalState>();
-}
+    atomic<bool> sent_schema;
+    mutex        lock;
+  };
 
-unique_ptr<GlobalTableFunctionState>
-ToArrowIPCFunction::InitGlobal(ClientContext &context,
-                               TableFunctionInitInput &input) {
-  return make_uniq<ToArrowIpcGlobalState>();
-}
+  struct ToArrowIpcLocalState: public LocalTableFunctionState {
+    unique_ptr<ArrowAppender> appender;
 
-unique_ptr<FunctionData>
-ToArrowIPCFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
-                         vector<LogicalType> &return_types,
-                         vector<string> &names) {
-  auto result = make_uniq<ToArrowIpcFunctionData>();
+    idx_t current_count  = 0;
+    bool  checked_schema = false;
+  };
 
-  result->chunk_size = DEFAULT_CHUNK_SIZE * STANDARD_VECTOR_SIZE;
 
-  // Set return schema
-  return_types.emplace_back(LogicalType::BLOB);
-  names.emplace_back("ipc");
-  return_types.emplace_back(LogicalType::BOOLEAN);
-  names.emplace_back("header");
-
-  // Create the Arrow schema
-  ArrowSchema schema;
-  ArrowConverter::ToArrowSchema(&schema, input.input_table_types,
-                                input.input_table_names,
-                                context.GetClientProperties());
-  result->schema = arrow::ImportSchema(&schema).ValueOrDie();
-
-  return std::move(result);
-}
-
-OperatorResultType ToArrowIPCFunction::Function(ExecutionContext &context,
-                                                TableFunctionInput &data_p,
-                                                DataChunk &input,
-                                                DataChunk &output) {
-  std::shared_ptr<arrow::Buffer> arrow_serialized_ipc_buffer;
-  auto &data = (ToArrowIpcFunctionData &)*data_p.bind_data;
-  auto &local_state = (ToArrowIpcLocalState &)*data_p.local_state;
-  auto &global_state = (ToArrowIpcGlobalState &)*data_p.global_state;
-
-  bool sending_schema = false;
-
-  bool caching_disabled = !PhysicalOperator::OperatorCachingAllowed(context);
-
-  if (!local_state.checked_schema) {
-    if (!global_state.sent_schema) {
-      lock_guard<mutex> init_lock(global_state.lock);
-      if (!global_state.sent_schema) {
-        // This run will send the schema, other threads can just send the
-        // buffers
-        global_state.sent_schema = true;
-        sending_schema = true;
-      }
-    }
-    local_state.checked_schema = true;
+  unique_ptr<LocalTableFunctionState>
+  ToArrowIPCFunction::InitLocal( ExecutionContext&         context
+                                ,TableFunctionInitInput&   input
+                                ,GlobalTableFunctionState* global_state) {
+    return make_uniq<ToArrowIpcLocalState>();
   }
 
-  if (sending_schema) {
-    auto result = arrow::ipc::SerializeSchema(*data.schema);
-    arrow_serialized_ipc_buffer = result.ValueOrDie();
-    output.data[1].SetValue(0, Value::BOOLEAN(1));
-  } else {
-    if (!local_state.appender) {
-      local_state.appender =
-          make_uniq<ArrowAppender>(input.GetTypes(), data.chunk_size,
-                                   context.client.GetClientProperties());
+  unique_ptr<GlobalTableFunctionState>
+  ToArrowIPCFunction::InitGlobal( ClientContext&          context
+                                 ,TableFunctionInitInput& input) {
+    return make_uniq<ToArrowIpcGlobalState>();
+  }
+
+  unique_ptr<FunctionData>
+  ToArrowIPCFunction::Bind( ClientContext&          context
+                           ,TableFunctionBindInput& input
+                           ,vector<LogicalType>&    return_types
+                           ,vector<string>&         names) {
+    auto result = make_uniq<ToArrowIpcFunctionData>();
+    result->chunk_size = DEFAULT_CHUNK_SIZE * STANDARD_VECTOR_SIZE;
+
+    // Set return schema
+    return_types.emplace_back(LogicalType::BLOB);
+    names.emplace_back("ipc");
+
+    return_types.emplace_back(LogicalType::BOOLEAN);
+    names.emplace_back("header");
+
+    // Create the Arrow schema
+    ArrowSchema schema;
+    ArrowConverter::ToArrowSchema(
+       &schema
+      ,input.input_table_types
+      ,input.input_table_names
+      ,context.GetClientProperties()
+    );
+
+    result->schema = arrow::ImportSchema(&schema).ValueOrDie();
+
+    return std::move(result);
+  }
+
+  OperatorResultType ToArrowIPCFunction::Function( ExecutionContext&   context
+                                                  ,TableFunctionInput& data_p
+                                                  ,DataChunk&          input
+                                                  ,DataChunk&          output) {
+    std::shared_ptr<arrow::Buffer> arrow_serialized_ipc_buffer;
+
+    auto& data         = (ToArrowIpcFunctionData &) *data_p.bind_data;
+    auto& local_state  = (ToArrowIpcLocalState   &) *data_p.local_state;
+    auto& global_state = (ToArrowIpcGlobalState  &) *data_p.global_state;
+
+    bool sending_schema   = false;
+    bool caching_disabled = !PhysicalOperator::OperatorCachingAllowed(context);
+
+    if (!local_state.checked_schema) {
+
+      if (!global_state.sent_schema) {
+        lock_guard<mutex> init_lock(global_state.lock);
+
+        // This run will send the schema, other threads can just send the buffers
+        if (!global_state.sent_schema) {
+            global_state.sent_schema = true;
+            sending_schema           = true;
+        }
+      }
+
+      local_state.checked_schema = true;
     }
 
-    // Append input chunk
-    local_state.appender->Append(input, 0, input.size(), input.size());
-    local_state.current_count += input.size();
+    if (sending_schema) {
+      auto result = arrow::ipc::SerializeSchema(*data.schema);
+      arrow_serialized_ipc_buffer = result.ValueOrDie();
+      output.data[1].SetValue(0, Value::BOOLEAN(1));
+    }
 
-    // If chunk size is reached, we can flush to IPC blob
-    if (caching_disabled || local_state.current_count >= data.chunk_size) {
+    else {
+      if (!local_state.appender) {
+        local_state.appender = make_uniq<ArrowAppender>(
+           input.GetTypes()
+          ,data.chunk_size
+          ,context.client.GetClientProperties()
+        );
+      }
+
+      // Append input chunk
+      local_state.appender->Append(input, 0, input.size(), input.size());
+      local_state.current_count += input.size();
+
+      // Request more data if we're allowed to hold data and we're under a chunk size
+      if (not caching_disabled && local_state.current_count < data.chunk_size) {
+          return OperatorResultType::NEED_MORE_INPUT;
+      }
+
+      // Otherwise, if chunk size is reached, flush to IPC blob then clean up
+
       // Construct record batch from DataChunk
-      ArrowArray arr = local_state.appender->Finalize();
-      auto record_batch =
-          arrow::ImportRecordBatch(&arr, data.schema).ValueOrDie();
+      ArrowArray arr    = local_state.appender->Finalize();
+      auto record_batch = arrow::ImportRecordBatch(&arr, data.schema).ValueOrDie();
 
       // Serialize recordbatch
       auto options = arrow::ipc::IpcWriteOptions::Defaults();
-      auto result = arrow::ipc::SerializeRecordBatch(*record_batch, options);
+      auto result  = arrow::ipc::SerializeRecordBatch(*record_batch, options);
+
       arrow_serialized_ipc_buffer = result.ValueOrDie();
 
       // Reset appender
@@ -142,68 +162,77 @@ OperatorResultType ToArrowIPCFunction::Function(ExecutionContext &context,
       local_state.current_count = 0;
 
       output.data[1].SetValue(0, Value::BOOLEAN(0));
-    } else {
-      return OperatorResultType::NEED_MORE_INPUT;
     }
-  }
 
-  // TODO clean up
-  auto wrapped_buffer =
-      make_buffer<ArrowStringVectorBuffer>(arrow_serialized_ipc_buffer);
-  auto &vector = output.data[0];
-  StringVector::AddBuffer(vector, wrapped_buffer);
-  auto data_ptr = (string_t *)vector.GetData();
-  *data_ptr = string_t((const char *)arrow_serialized_ipc_buffer->data(),
-                       arrow_serialized_ipc_buffer->size());
-  output.SetCardinality(1);
-
-  if (sending_schema) {
-    return OperatorResultType::HAVE_MORE_OUTPUT;
-  } else {
-    return OperatorResultType::NEED_MORE_INPUT;
-  }
-}
-
-OperatorFinalizeResultType ToArrowIPCFunction::FunctionFinal(
-    ExecutionContext &context, TableFunctionInput &data_p, DataChunk &output) {
-  auto &data = (ToArrowIpcFunctionData &)*data_p.bind_data;
-  auto &local_state = (ToArrowIpcLocalState &)*data_p.local_state;
-  std::shared_ptr<arrow::Buffer> arrow_serialized_ipc_buffer;
-
-  // TODO clean up
-  if (local_state.appender) {
-    ArrowArray arr = local_state.appender->Finalize();
-    auto record_batch =
-        arrow::ImportRecordBatch(&arr, data.schema).ValueOrDie();
-
-    // Serialize recordbatch
-    auto options = arrow::ipc::IpcWriteOptions::Defaults();
-    auto result = arrow::ipc::SerializeRecordBatch(*record_batch, options);
-    arrow_serialized_ipc_buffer = result.ValueOrDie();
-
-    auto wrapped_buffer =
-        make_buffer<ArrowStringVectorBuffer>(arrow_serialized_ipc_buffer);
-    auto &vector = output.data[0];
+    // TODO clean up
+    auto wrapped_buffer = make_buffer<ArrowStringVectorBuffer>(arrow_serialized_ipc_buffer);
+    auto& vector = output.data[0];
     StringVector::AddBuffer(vector, wrapped_buffer);
-    auto data_ptr = (string_t *)vector.GetData();
-    *data_ptr = string_t((const char *)arrow_serialized_ipc_buffer->data(),
-                         arrow_serialized_ipc_buffer->size());
+
+    auto data_ptr = (string_t *) vector.GetData();
+    *data_ptr = string_t(
+       (const char *) arrow_serialized_ipc_buffer->data()
+      ,               arrow_serialized_ipc_buffer->size()
+    );
+
     output.SetCardinality(1);
-    local_state.appender.reset();
-    output.data[1].SetValue(0, Value::BOOLEAN(0));
+
+    if (sending_schema) { return OperatorResultType::HAVE_MORE_OUTPUT; }
+    else                { return OperatorResultType::NEED_MORE_INPUT;  }
   }
 
-  return OperatorFinalizeResultType::FINISHED;
-}
 
-TableFunction ToArrowIPCFunction::GetFunction() {
-  TableFunction fun("to_arrow_ipc", {LogicalType::TABLE}, nullptr,
-                    ToArrowIPCFunction::Bind, ToArrowIPCFunction::InitGlobal,
-                    ToArrowIPCFunction::InitLocal);
-  fun.in_out_function = ToArrowIPCFunction::Function;
-  fun.in_out_function_final = ToArrowIPCFunction::FunctionFinal;
+  OperatorFinalizeResultType ToArrowIPCFunction::FunctionFinal( ExecutionContext&   context
+                                                               ,TableFunctionInput& data_p
+                                                               ,DataChunk&          output) {
+      auto& data        = (ToArrowIpcFunctionData &) *data_p.bind_data;
+      auto& local_state = (ToArrowIpcLocalState   &) *data_p.local_state;
 
-  return fun;
-}
+      std::shared_ptr<arrow::Buffer> arrow_serialized_ipc_buffer;
+
+      // TODO clean up
+      if (local_state.appender) {
+        ArrowArray arr    = local_state.appender->Finalize();
+        auto record_batch = arrow::ImportRecordBatch(&arr, data.schema).ValueOrDie();
+
+        // Serialize recordbatch
+        auto options = arrow::ipc::IpcWriteOptions::Defaults();
+        auto result  = arrow::ipc::SerializeRecordBatch(*record_batch, options);
+        arrow_serialized_ipc_buffer = result.ValueOrDie();
+
+        auto wrapped_buffer = make_buffer<ArrowStringVectorBuffer>(arrow_serialized_ipc_buffer);
+        auto& vector = output.data[0];
+        StringVector::AddBuffer(vector, wrapped_buffer);
+
+        auto data_ptr = (string_t *) vector.GetData();
+        *data_ptr = string_t(
+           (const char *) arrow_serialized_ipc_buffer->data()
+          ,               arrow_serialized_ipc_buffer->size()
+        );
+
+        output.SetCardinality(1);
+        local_state.appender.reset();
+        output.data[1].SetValue(0, Value::BOOLEAN(0));
+      }
+
+      return OperatorFinalizeResultType::FINISHED;
+  }
+
+
+  TableFunction ToArrowIPCFunction::GetFunction() {
+      TableFunction fun(
+         "to_arrow_ipc"
+        ,{ LogicalType::TABLE }
+        ,nullptr
+        ,ToArrowIPCFunction::Bind
+        ,ToArrowIPCFunction::InitGlobal
+        ,ToArrowIPCFunction::InitLocal
+      );
+
+      fun.in_out_function       = ToArrowIPCFunction::Function;
+      fun.in_out_function_final = ToArrowIPCFunction::FunctionFinal;
+
+      return fun;
+  }
 
 } // namespace duckdb

--- a/src/include/arrow_readers.hpp
+++ b/src/include/arrow_readers.hpp
@@ -1,0 +1,51 @@
+// ------------------------------
+// License
+//
+// Copyright 2024 Aldrin Montana
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// ------------------------------
+// Dependencies
+
+#include "arrow_stream_buffer.hpp"
+
+
+// ------------------------------
+// Aliases
+
+
+
+// ------------------------------
+// Public prototypes
+
+// >> Reader functions
+namespace duckdb {
+  arrow::Result<std::shared_ptr<arrow::Buffer>>
+  BufferFromIPCStream(const std::string& path_to_file);
+
+  /*
+  Result<shared_ptr<arrow::Table>>
+  ReadIPCStream(const std::string& path_to_file);
+
+  Result<shared_ptr<arrow::Table>>
+  ReadIPCFile  (const std::string& path_to_file);
+  */
+
+  arrow::Status
+  ConsumeArrowStream( std::shared_ptr<ArrowIPCStreamBuffer> ipc_buffer
+                     ,vector<Value>                         input_buffers);
+
+  Value ValueForIPCBuffer(arrow::Buffer& ipc_buffer);
+}

--- a/src/include/arrow_scan_ipc.hpp
+++ b/src/include/arrow_scan_ipc.hpp
@@ -17,8 +17,9 @@ namespace duckdb {
     // A delegate constructor that takes an IPC buffer
     ArrowIPCScanFunctionData( stream_factory_produce_t              reader_factory
                              ,std::shared_ptr<ArrowIPCStreamBuffer> arrow_buffer)
-      : ArrowScanFunctionData(reader_factory, (uintptr_t) &arrow_buffer) {
-      ipc_buffer = arrow_buffer;
+      : ArrowScanFunctionData(reader_factory, 0ULL) {
+      ipc_buffer         = std::move(arrow_buffer);
+      stream_factory_ptr = (uintptr_t) &ipc_buffer;
     }
 
     // An attribute to keep the decoded arrow data alive

--- a/src/include/arrow_scan_ipc.hpp
+++ b/src/include/arrow_scan_ipc.hpp
@@ -23,6 +23,7 @@ namespace duckdb {
 
     // An attribute to keep the decoded arrow data alive
     std::shared_ptr<ArrowIPCStreamBuffer>       ipc_buffer { nullptr };
+    std::unordered_map<std::string, bool>       file_opened;
     std::vector<std::shared_ptr<arrow::Buffer>> file_buffers;
   };
 

--- a/src/include/arrow_scan_ipc.hpp
+++ b/src/include/arrow_scan_ipc.hpp
@@ -5,27 +5,47 @@
 
 #include "duckdb.hpp"
 
+using ArrowIPCDec = arrow::ipc::StreamDecoder;
+
 namespace duckdb {
 
-struct ArrowIPCScanFunctionData : public ArrowScanFunctionData {
-public:
-  using ArrowScanFunctionData::ArrowScanFunctionData;
-  unique_ptr<BufferingArrowIPCStreamDecoder> stream_decoder = nullptr;
-};
+  //! Data wrapper for Arrow IPC Scan function data
+  struct ArrowIPCScanFunctionData : public ArrowScanFunctionData {
+    // Reuse the constructor of parent class
+    using ArrowScanFunctionData::ArrowScanFunctionData;
 
-// IPC Table scan is identical to ArrowTableFunction arrow scan except instead
-// of CDataInterface header pointers, it takes a bunch of pointers pointing to
-// buffers containing data in Arrow IPC format
-struct ArrowIPCTableFunction : public ArrowTableFunction {
-public:
-  static TableFunction GetFunction();
+    // A delegate constructor that takes an IPC buffer
+    ArrowIPCScanFunctionData( stream_factory_produce_t              reader_factory
+                             ,std::shared_ptr<ArrowIPCStreamBuffer> arrow_buffer)
+      : ArrowScanFunctionData(reader_factory, (uintptr_t) &arrow_buffer) {
+      ipc_buffer = arrow_buffer;
+    }
 
-private:
-  static unique_ptr<FunctionData>
-  ArrowScanBind(ClientContext &context, TableFunctionBindInput &input,
-                vector<LogicalType> &return_types, vector<string> &names);
-  static void ArrowScanFunction(ClientContext &context,
-                                TableFunctionInput &data_p, DataChunk &output);
-};
+    // An attribute to keep the decoded arrow data alive
+    std::shared_ptr<ArrowIPCStreamBuffer> ipc_buffer { nullptr };
+  };
+
+  /**
+   * ArrowIPCTableScan receives pointers to IPC buffers and returns a DuckDB Table.
+   * This implementation is logically identical to ArrowTableFunction arrow scan
+   * (used by PyRelation) which takes CDataInterface header pointers instead.
+   */
+  struct ArrowIPCTableFunction : public ArrowTableFunction {
+    public:
+      //! Returns a constructed instance of ArrowIPCTableFunction
+      static TableFunction GetFunction();
+
+    private:
+      static unique_ptr<FunctionData>
+      ArrowScanBind( ClientContext&          context
+                    ,TableFunctionBindInput& input
+                    ,vector<LogicalType>&    return_types
+                    ,vector<string>&         names);
+
+      static void
+      ArrowScanFunction( ClientContext&      context
+                        ,TableFunctionInput& data_p
+                        ,DataChunk&          output);
+  };
 
 } // namespace duckdb

--- a/src/include/arrow_stream_buffer.hpp
+++ b/src/include/arrow_stream_buffer.hpp
@@ -15,10 +15,18 @@
 #include "arrow/type.h"
 #include "arrow/status.h"
 #include "arrow/result.h"
+#include "arrow/buffer.h"
 #include "arrow/record_batch.h"
 
+#include "arrow/io/file.h"
 #include "arrow/ipc/reader.h"
 #include "arrow/c/bridge.h"
+
+
+// ------------------------------
+// Convenience Aliases
+
+using ArrowIPCDec = arrow::ipc::StreamDecoder;
 
 
 // >> Custom parsing of Arrow IPC

--- a/src/include/arrow_stream_buffer.hpp
+++ b/src/include/arrow_stream_buffer.hpp
@@ -73,7 +73,7 @@ namespace duckdb {
   CStreamForIPCBuffer(uintptr_t buffer_ptr, ArrowStreamParameters &parameters);
 
   //! Uses an ArrowRecordBatchReader on the input IPC buffer to set schema
-  void SchemaFromIPCBuffer( shared_ptr<ArrowIPCStreamBuffer> buffer
-                           ,ArrowSchemaWrapper&              schema);
+  void SchemaFromIPCBuffer( std::shared_ptr<ArrowIPCStreamBuffer> buffer
+                           ,ArrowSchemaWrapper&                   schema);
 
 } // namespace duckdb

--- a/src/include/arrow_stream_buffer.hpp
+++ b/src/include/arrow_stream_buffer.hpp
@@ -65,6 +65,7 @@ namespace duckdb {
   CStreamForIPCBuffer(uintptr_t buffer_ptr, ArrowStreamParameters &parameters);
 
   //! Uses an ArrowRecordBatchReader on the input IPC buffer to set schema
-  void SchemaFromIPCBuffer(uintptr_t buffer_ptr, ArrowSchemaWrapper& schema);
+  void SchemaFromIPCBuffer( shared_ptr<ArrowIPCStreamBuffer> buffer
+                           ,ArrowSchemaWrapper&              schema);
 
 } // namespace duckdb

--- a/src/include/arrow_to_ipc.hpp
+++ b/src/include/arrow_to_ipc.hpp
@@ -3,42 +3,53 @@
 #include "arrow/buffer.h"
 #include "duckdb.hpp"
 
-#include <memory>
 
 namespace duckdb {
 
-class ArrowStringVectorBuffer : public VectorBuffer {
-public:
-  explicit ArrowStringVectorBuffer(std::shared_ptr<arrow::Buffer> buffer_p)
-      : VectorBuffer(VectorBufferType::OPAQUE_BUFFER),
-        buffer(std::move(buffer_p)) {}
+  class ArrowStringVectorBuffer : public VectorBuffer {
+    public:
+      explicit ArrowStringVectorBuffer(std::shared_ptr <arrow::Buffer> buffer_p)
+        :  VectorBuffer(VectorBufferType::OPAQUE_BUFFER)
+          ,buffer      (std::move(buffer_p)            ) {}
 
-private:
-  std::shared_ptr<arrow::Buffer> buffer;
-};
+    private:
+      std::shared_ptr<arrow::Buffer> buffer;
+  };
 
-class ToArrowIPCFunction {
-public:
-  //! note: this is the number of vectors per chunk
-  static constexpr idx_t DEFAULT_CHUNK_SIZE = 120;
 
-  static TableFunction GetFunction();
+  class ToArrowIPCFunction {
+    public:
+      //! note: this is the number of vectors per chunk
+      static constexpr idx_t DEFAULT_CHUNK_SIZE = 120;
 
-private:
-  static unique_ptr<LocalTableFunctionState>
-  InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
-            GlobalTableFunctionState *global_state);
-  static unique_ptr<GlobalTableFunctionState>
-  InitGlobal(ClientContext &context, TableFunctionInitInput &input);
-  static unique_ptr<FunctionData> Bind(ClientContext &context,
-                                       TableFunctionBindInput &input,
-                                       vector<LogicalType> &return_types,
-                                       vector<string> &names);
-  static OperatorResultType Function(ExecutionContext &context,
-                                     TableFunctionInput &data_p,
-                                     DataChunk &input, DataChunk &output);
-  static OperatorFinalizeResultType FunctionFinal(ExecutionContext &context,
-                                                  TableFunctionInput &data_p,
-                                                  DataChunk &output);
-}; // namespace duckdb
+      static TableFunction GetFunction();
+
+    private:
+      static unique_ptr<LocalTableFunctionState>
+      InitLocal( ExecutionContext&         context
+                ,TableFunctionInitInput&   input
+                ,GlobalTableFunctionState* global_state);
+
+      static unique_ptr<GlobalTableFunctionState>
+      InitGlobal(ClientContext& context, TableFunctionInitInput& input);
+
+      static unique_ptr<FunctionData>
+      Bind( ClientContext&          context
+           ,TableFunctionBindInput& input
+           ,vector<LogicalType>&    return_types
+           ,vector<string>&         names);
+
+      static OperatorResultType
+      Function( ExecutionContext&   context
+               ,TableFunctionInput& data_p
+               ,DataChunk&          input
+               ,DataChunk&          output);
+
+      static OperatorFinalizeResultType
+      FunctionFinal( ExecutionContext&   context
+                    ,TableFunctionInput& data_p
+                    ,DataChunk&          output);
+
+  };
+
 } // namespace duckdb


### PR DESCRIPTION
This would be a first release of my fork of the arrow extension. I'm not sure what to version it, so I'll think about the exact logistics over the next week.

This does not change much of the upstream arrow extension for duckdb, but I would like to add quite a bit of convenience code as well as close the gap with some substrait functionality. Specifically, I would like to eventually:
1. Handle substrait ReadRel operators backed by arrow formatted files (IPC file and IPC stream).
2. Add convenience code that makes it much easier to get Arrow data into duckdb and out of duckdb (via C++ bindings).
3. Perhaps add bindings for flight to make it easy to connect to a remote duckdb server.

This release would include initial implementations to support (1) and refactors code (and adds convenience functions) towards satisfying (2). For (3), I have code in another repository that I will try to "upstream" here in the future, depending on if I can think of a way for it to feel cohesive (maybe I'll look at the http extension or something of the sort for guidance).

Also, recent updates to the substrait extension replace TableFunction definitions that return `QueryResult`s to TableFunciton definitions that return `TableRef`s. So, I would like to look into that as well.

Anyways, this release is a satisfactory first step in these directions and should make for a good base on which to make future PRs.